### PR TITLE
Trim spaces from csv fields.

### DIFF
--- a/datamodels/csv/src/main/java/net/fhirfactory/pegacorn/csv/core/CSVRowBean.java
+++ b/datamodels/csv/src/main/java/net/fhirfactory/pegacorn/csv/core/CSVRowBean.java
@@ -53,7 +53,7 @@ public abstract class CSVRowBean {
         }
 
         for (int i = 0; i < rowData.length; i++) {
-            this.rowData[i] = rowData[i];
+            this.rowData[i] = rowData[i].trim();
         }
     }
 


### PR DESCRIPTION
Some of the CSV files have had trailing spaces in fields which need to be removed as it is causing issues during field comparisions.