### PR TITLE
Add methods to move segments to the end of the message

### DIFF
--- a/datamodels/hl7v2x/src/main/java/net/fhirfactory/pegacorn/internals/hl7v2/HL7Message.java
+++ b/datamodels/hl7v2x/src/main/java/net/fhirfactory/pegacorn/internals/hl7v2/HL7Message.java
@@ -371,7 +371,29 @@ public class HL7Message implements Serializable   {
 			
 		getSegments().remove(sourceSegment);
 	}
+
 	
+	/**
+	 * Moves the segment at the supplied index to the end of the message.
+	 * 
+	 * @param currentIndex
+	 * @throws Exception
+	 */
+	public void moveSegmentToEnd(int currentIndex) throws Exception {
+		moveSegment(currentIndex, getSegments().size() + 1);
+	}
+
+	
+	/**
+	 * Moves the segment to the end of the message.
+	 * 
+	 * @param currentIndex
+	 * @throws Exception
+	 */
+	public void moveSegmentToEnd(Segment segment) throws Exception {	
+		moveSegmentToEnd(getSegmentIndex(segment));
+	}	
+
 	
 	/**
 	 * Insert a segment.


### PR DESCRIPTION
A new transformation rule is to move segments to the end of the message and easier and better to write a reusable java method which can be used elsewhere